### PR TITLE
fix: correct goreleaser ldflags path for version injection

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
       - linux
     ldflags:
       # The line below MUST align with the module in current provider/go.mod
-      - -X github.com/lukeshay/pulumi-flyio/provider/Version={{.Tag }}
+      - -X github.com/lukeshay/pulumi-flyio/provider/pkg/provider.Version={{.Tag }}
     main: ./cmd/pulumi-resource-flyio/
 changelog:
   disable: true


### PR DESCRIPTION
## Summary

The goreleaser ldflags path for version injection is incorrect, causing all released binaries to have an empty version string.

**Current (wrong):**
```
-X github.com/lukeshay/pulumi-flyio/provider/Version={{.Tag }}
```

**Fixed:**
```
-X github.com/lukeshay/pulumi-flyio/provider/pkg/provider.Version={{.Tag }}
```

The `Version` variable is declared in `provider/pkg/provider/provider.go` (line 20), but goreleaser was targeting `provider/Version` which doesn't resolve to any Go symbol. The Makefile already uses the correct path (`provider/pkg/provider.Version`).

## Impact

Without this fix, every released binary reports an empty version string, causing:
- Pulumi warnings: `resource plugin flyio is expected to have version >=X, but has`
- Provider drift detection on every `pulumi up` (provider gets replaced each run)
- Cascading resource replacements when the provider is replaced

## Test plan

- [ ] Build with goreleaser and verify `pulumi plugin ls` shows the correct version
- [ ] Run `pulumi preview` and confirm no `resource plugin flyio is expected to have version` warnings